### PR TITLE
Tap-to-Move

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,8 +10,11 @@ function App() {
         isResettingBoard,
         playerColor,
         playerColorFull,
+        focusedSquare,
+        focusedSquareLegalMoves,
         resetGameHandler,
-        pieceDroppedHandler
+        pieceDroppedHandler,
+        squareTappedHandler
     } = useGame();
 
     return (
@@ -22,8 +25,11 @@ function App() {
                 isResettingBoard={isResettingBoard}
                 playerColor={playerColor}
                 playerColorFull={playerColorFull}
+                focusedSquare={focusedSquare}
+                focusedSquareLegalMoves={focusedSquareLegalMoves}
                 resetGameHandler={resetGameHandler}
-                pieceDroppedHandler={pieceDroppedHandler} />
+                pieceDroppedHandler={pieceDroppedHandler}
+                squareTappedHandler={squareTappedHandler} />
             <Toolbar resetGameHandler={resetGameHandler} />
         </div>
     );

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -45,10 +45,24 @@ const Game = ({
     isResettingBoard,
     playerColor,
     playerColorFull,
-    pieceDroppedHandler }) => {
+    pieceDroppedHandler,
+    focusedSquare,
+    focusedSquareLegalMoves,
+    squareTappedHandler }) => {
 
     // The board width in pixels, as required by react-chessboard.
     const [boardWidth, setBoardWidth] = useState(window.visualViewport.width);
+
+    const moveOptionsStyles = {};
+    focusedSquareLegalMoves.forEach(m => {
+        moveOptionsStyles[m.to] = {
+            background:
+                game.get(m.to) && game.get(m.to).color !== game.get(focusedSquare).color
+                    ? 'radial-gradient(circle, rgba(0,0,0,.1) 85%, transparent 85%)'
+                    : 'radial-gradient(circle, rgba(0,0,0,.1) 25%, transparent 25%)',
+            borderRadius: '50%'
+        }
+    });
 
     // Manages the width of the board in pixels.
     useEffect(() => {
@@ -77,6 +91,9 @@ const Game = ({
                 boardWidth={boardWidth}
                 position={game.fen()}
                 onPieceDrop={pieceDroppedHandler}
+                onPieceDragBegin={() => squareTappedHandler(null)}
+                onSquareClick={squareTappedHandler}
+                customSquareStyles={moveOptionsStyles}
                 snapToCursor={true}
                 animationDuration={game.history().length === 0 ? 0 : 300}
                 key='main'

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -14,6 +14,9 @@ const useGame = () => {
     const [playerColor, setPlayerColor] = useState();
     const playerColorFull = playerColor === 'w' ? 'white' : 'black';
 
+    const [focusedSquare, setFocusedSquare] = useState();
+    const focusedSquareLegalMoves = focusedSquare ? game.moves({ square: focusedSquare, verbose: true }) : [];
+
     // Manages what happens after each the game state changes.
     useEffect(() => {
         if (oldGameState) { return }
@@ -35,8 +38,8 @@ const useGame = () => {
             // Call API to get next move.
             const controller = new AbortController();
 
-            chessAPI.post('/suggest-move', { 
-                'board_position': game.fen() 
+            chessAPI.post('/suggest-move', {
+                'board_position': game.fen()
             }, {
                 signal: controller.signal
             }).then(response => {
@@ -121,14 +124,46 @@ const useGame = () => {
         return validMove !== null;
     }
 
+    // Handles the event where a piece is tapped.
+    const squareTappedHandler = square => {
+        if (!square) {
+            setFocusedSquare(undefined);
+            return null;
+        }
+
+        const pieceOnSquare = game.get(square);
+
+        if (focusedSquare && pieceOnSquare) {
+            setFocusedSquare(square);
+            return null;
+
+        } else if (focusedSquare) {
+            const move = {
+                from: focusedSquare,
+                to: square
+            }
+
+            const validMove = makeMove(move);
+            setFocusedSquare(undefined);
+            return validMove !== null;
+
+        } else if (pieceOnSquare) {
+            setFocusedSquare(square);
+            return null;
+        }
+    }
+
     return {
         game,
         oldGameState,
         isResettingBoard,
         playerColor,
         playerColorFull,
+        focusedSquare,
+        focusedSquareLegalMoves,
         resetGameHandler,
-        pieceDroppedHandler
+        pieceDroppedHandler,
+        squareTappedHandler
     }
 }
 


### PR DESCRIPTION
## Changes

In addition to dragging pieces, players can now tap a piece and the square to which it should move.

## How was this tested?

Tested manually in the browser.