### PR TITLE
Basic desktop optimization, mostly through CSS media queries.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import useGame from './hooks/useGame';
 import Game from './components/Game';
 import ResetBubbleArea from './components/ResetBubbleArea';
+import Toolbar from './components/Toolbar';
 
 
 function App() {
@@ -41,6 +42,7 @@ function App() {
                 squareTappedHandler={squareTappedHandler}
                 isPieceMovableHandler={isPieceMovableHandler} />
             <ResetBubbleArea onBubblePopped={resetGameHandler} />
+            <Toolbar resetGameHandler={resetGameHandler} />
         </div>
     );
 }

--- a/src/components/CheckIndicator.js
+++ b/src/components/CheckIndicator.js
@@ -15,6 +15,10 @@ padding: 0 8px;
 transform: ${props => props.showing ? 'translateX(0)' : 'translateX(-50px)'};
 opacity: ${props => props.showing ? '100%' : '0'};
 transition: transform 0.3s ease, opacity 0.3s ease;
+
+@media (min-width: 40rem) {
+    font-size: 1rem;
+}
 `;
 
 const CheckIndicator = ({ check, checkmate }) => (

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { Chessboard } from 'react-chessboard';
 import Spinner from './Spinner';
@@ -7,9 +7,16 @@ import CheckIndicator from './CheckIndicator';
 const GameContainer = styled.div`
 display: grid;
 grid-template-rows: 2.5rem auto 2.5rem;
+margin: auto;
 margin-top: 3rem;
 width: 100%
 overflow: hidden;
+max-width: 40rem;
+position: relative;
+
+@media (min-width: 40rem) {
+    grid-template-rows: 3rem auto 3rem;
+}
 `;
 
 const InfoContainer = styled.div`
@@ -28,6 +35,10 @@ const ChessboardCell = styled.div`
 width: 100vw;
 overflow: hidden;
 aspect-ratio: 1 / 1;
+
+@media (min-width: 40rem) {
+    width: 40rem;
+}
 `;
 
 const ChessboardContainer = styled.div`
@@ -40,6 +51,11 @@ width: ${props => props.isResettingBoard ? 'calc(200vw + 2rem)' : 'initial'};
 column-gap: ${props => props.isResettingBoard ? '2rem' : 'initial'};
 transform: ${props => props.isResettingBoard ? 'translateX(calc(-100vw - 2rem))' : 'initial'};
 transition: ${props => props.isResettingBoard ? 'transform 0.5s ease-in-out' : 'initial'};
+
+@media (min-width: 40rem) {
+    width: ${props => props.isResettingBoard ? 'calc(80rem + 2rem)' : 'initial'};
+    transform: ${props => props.isResettingBoard ? 'translateX(calc(-40rem - 2rem))' : 'initial'};
+}
 `;
 
 const Game = ({
@@ -59,7 +75,8 @@ const Game = ({
     isPieceMovableHandler }) => {
 
     // The board width in pixels, as required by react-chessboard.
-    const [boardWidth, setBoardWidth] = useState(window.visualViewport.width);
+    const [boardWidth, setBoardWidth] = useState(window.visualViewport.width < 640 ? window.visualViewport.width : 640);
+    const boardAreaRef = useRef();
 
     const squareStyles = {};
     focusedSquareLegalMoves.forEach(m => {
@@ -79,17 +96,9 @@ const Game = ({
 
     // Manages the width of the board in pixels.
     useEffect(() => {
-        const resizeBoard = () => {
-            if (window.visualViewport.width < window.visualViewport.height) {
-                setBoardWidth(window.visualViewport.width);
-            } else {
-                setBoardWidth(window.visualViewport.height);
-            }
-        }
-
+        const resizeBoard = () => setBoardWidth(boardAreaRef.current.offsetWidth);
         window.addEventListener('resize', resizeBoard);
         return () => window.removeEventListener('resize', resizeBoard)
-
     }, [])
 
     // Chessboard array. If resetting a game, a board with the resigned game
@@ -133,7 +142,7 @@ const Game = ({
                 <CheckIndicator check={opponentCheck} checkmate={opponentCheckmate} />
                 <Spinner hidden={!game || game.turn() === playerColor || game.game_over()} />
             </OpponentInfo>
-            <ChessboardCell>
+            <ChessboardCell ref={boardAreaRef}>
                 <ChessboardContainer isResettingBoard={isResettingBoard}>
                     {chessBoards}
                 </ChessboardContainer>

--- a/src/components/ResetBubbleArea.js
+++ b/src/components/ResetBubbleArea.js
@@ -1,5 +1,15 @@
 import { useState } from 'react';
+import styled from 'styled-components';
 import ResetBubble from './ResetBubble';
+
+const Area = styled.div`
+height: 8rem;
+position: relative;
+
+@media (min-width: 40rem) {
+    display: none;
+}
+`;
 
 const ResetBubbleArea = ({ onBubblePopped }) => {
     const [coordinates, setCoordinates] = useState();
@@ -22,14 +32,13 @@ const ResetBubbleArea = ({ onBubblePopped }) => {
     }
 
     return (
-        <div
-            style={{ height: '8rem', position: 'relative' }}
+        <Area
             onMouseDown={mouseDownHandler}
             onMouseUp={endHandler}
             onTouchStart={touchStartHandler}
             onTouchEnd={endHandler}>
                 {coordinates && <ResetBubble onBubblePopped={onBubblePopped} coordinates={coordinates} />}
-        </div>
+        </Area>
     )
 }
 

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -15,6 +15,11 @@ animation-name: ${rotate};
 animation-duration: 0.75s;
 animation-iteration-count: infinite;
 animation-timing-function: linear;
+
+@media (min-width: 40rem) {
+    height: 32px;
+    width: 32px;
+}
 `;
 
 const Arc = styled.circle`

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,15 +1,20 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
+display: none;
 position: fixed;
 padding: 8px 4px calc(env(safe-area-inset-bottom) + 8px) 4px;
 bottom: 0;
 width: 100%;
 background-color: transparent;
-display: flex;
 flex-direction: row;
 justify-content: space-around;
 align-items: center;
+
+@media (min-width: 40rem) {
+    display: flex;
+    position: static;
+}
 `;
 
 const ResetButton = styled.button`


### PR DESCRIPTION
## Changes

The desktop view caps the board size at `40rem`. In the desktop view, the hold-to-refresh feature is replaced with a button to reset the board.

## How was this tested?

Tested manually in the browser.

## Notes to reviewer

The focus for now is on a mobile interface. This desktop interface will be improved later, but these updates are just to make it playable in a desktop browser.