### PR TITLE
Indicators now support stalemates and draw games.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,9 @@ function App() {
         playerCheck,
         opponentCheckmate,
         playerCheckmate,
+        opponentStalemate,
+        playerStalemate,
+        isDrawGame,
         resetGameHandler,
         pieceDroppedHandler,
         squareTappedHandler,
@@ -37,6 +40,9 @@ function App() {
                 playerCheck={playerCheck}
                 opponentCheckmate={opponentCheckmate}
                 playerCheckmate={playerCheckmate}
+                opponentStalemate={opponentStalemate}
+                playerStalemate={playerStalemate}
+                isDrawGame={isDrawGame}
                 resetGameHandler={resetGameHandler}
                 pieceDroppedHandler={pieceDroppedHandler}
                 squareTappedHandler={squareTappedHandler}

--- a/src/components/CheckIndicator.js
+++ b/src/components/CheckIndicator.js
@@ -21,8 +21,17 @@ transition: transform 0.3s ease, opacity 0.3s ease;
 }
 `;
 
-const CheckIndicator = ({ check, checkmate }) => (
-    <Indicator showing={check || checkmate}>{checkmate ? 'Checkmate' : 'Check'}</Indicator>
-)
+const CheckIndicator = ({ check, checkmate, stalemate, draw }) => {
+    let text = 'Draw';
+    if (stalemate) {
+        text = 'Stalemate';
+    } else if (checkmate) {
+        text = 'Checkmate';
+    } else if (check) {
+        text = 'Check';
+    }
+    
+    return <Indicator showing={check || checkmate || stalemate || draw}>{text}</Indicator>
+}
 
 export default CheckIndicator;

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -71,6 +71,9 @@ const Game = ({
     playerCheck,
     opponentCheckmate,
     playerCheckmate,
+    opponentStalemate,
+    playerStalemate,
+    isDrawGame,
     squareTappedHandler,
     isPieceMovableHandler }) => {
 
@@ -139,7 +142,7 @@ const Game = ({
     return (
         <GameContainer>
             <OpponentInfo>
-                <CheckIndicator check={opponentCheck} checkmate={opponentCheckmate} />
+                <CheckIndicator check={opponentCheck} checkmate={opponentCheckmate} stalemate={opponentStalemate} draw={isDrawGame} />
                 <Spinner hidden={!game || game.turn() === playerColor || game.game_over()} />
             </OpponentInfo>
             <ChessboardCell ref={boardAreaRef}>
@@ -148,7 +151,7 @@ const Game = ({
                 </ChessboardContainer>
             </ChessboardCell>
             <PlayerInfo>
-                <CheckIndicator check={playerCheck} checkmate={playerCheckmate} />
+                <CheckIndicator check={playerCheck} checkmate={playerCheckmate} stalemate={playerStalemate} draw={isDrawGame} />
             </PlayerInfo>
         </GameContainer>
     )

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -158,7 +158,7 @@ const useGame = () => {
 
     const isPieceMovableHandler = ({ sourceSquare }) => {
         const pieceOnSquare = game.get(sourceSquare);
-        return pieceOnSquare && pieceOnSquare.color === playerColor && game.turn() === playerColor;
+        return pieceOnSquare && pieceOnSquare.color === playerColor && game && !game.game_over() && game.turn() === playerColor;
     }
 
     return {
@@ -173,6 +173,9 @@ const useGame = () => {
         playerCheck: game && game.turn() === playerColor && game.in_check(),
         opponentCheckmate: game && game.turn() !== playerColor && game.in_checkmate(),
         playerCheckmate: game && game.turn() === playerColor && game.in_checkmate(),
+        opponentStalemate: game && game.turn() !== playerColor && game.in_stalemate(),
+        playerStalemate: game && game.turn() === playerColor && game.in_stalemate(),
+        isDrawGame: game && game.in_draw(),
         resetGameHandler,
         pieceDroppedHandler,
         squareTappedHandler,


### PR DESCRIPTION
## Changes

In addition to Check and Checkmate, the indicators will show Stalemate for the player who has no legal move and Draw for both players. A draw will occur if any of the following happen: 

- Fifty half-moves occur without a pawn advance or piece capture.
- There is insufficient material to checkmate. (K v. k, KN v. k, KB v. k)
- Threefold repetition: the same board position occurred three or more times.